### PR TITLE
Add filler <td>s for dynamically-created iframes

### DIFF
--- a/css/jake-diagrams.css
+++ b/css/jake-diagrams.css
@@ -26,6 +26,11 @@
   border-left: dotted 2px;
 }
 
+.jake-diagram td.filler {
+  color: gray;
+  font-style: italic;
+}
+
 .jake-diagram .current {
   font-style: italic;
   font-weight: bold;

--- a/js/create-diagram.mjs
+++ b/js/create-diagram.mjs
@@ -72,8 +72,8 @@ export default input => {
       // We may have to create up to two <td> elements:
       //   1.) Definitely we'll create a <td> representing the session history entry that spans
       //       `endingStep - startingStep + 1` "steps".
-      //   2.) If the <td> from represents an <iframe> that was dynamically created sometime later
-      //       than step 0, then we create a "filler" <td> to fill the gap between step 0 and
+      //   2.) If the <td> from above represents an <iframe> that was dynamically created sometime
+      //       after step 0, then we create a "filler" <td> to fill the gap between step 0 and
       //       `startingStep`.
       if (startingStep > 0 && Array.from(tr.children).length == 1) {
         const filler_td = tr.appendChild(document.createElement("td"));

--- a/js/create-diagram.mjs
+++ b/js/create-diagram.mjs
@@ -69,8 +69,23 @@ export default input => {
       }
       maxStep = Math.max(maxStep, endingStep);
 
+      // We may have to create up to two <td> elements:
+      //   1.) Definitely we'll create a <td> representing the session history entry that spans
+      //       `endingStep - startingStep + 1` "steps".
+      //   2.) If the <td> from represents an <iframe> that was dynamically created sometime later
+      //       than step 0, then we create a "filler" <td> to fill the gap between step 0 and
+      //       `startingStep`.
+      if (startingStep > 0 && Array.from(tr.children).length == 1) {
+        const filler_td = tr.appendChild(document.createElement("td"));
+        filler_td.colSpan = startingStep;
+        filler_td.className = `doc-${docsToUse[docIndex]}`;
+        filler_td.textContent = url;
+        filler_td.docIndex = docIndex;
+        filler_td.classList.add("filler");
+      }
+
       const td = tr.appendChild(document.createElement("td"));
-      td.colSpan = endingStep - startingStep  + 1;
+      td.colSpan = endingStep - startingStep + 1;
       td.className = `doc-${docsToUse[docIndex]}`;
       td.docIndex = docIndex;
       td.textContent = url;


### PR DESCRIPTION
This isn't strictly necessary, so feel free to reject if you think it doesn't add much value, but https://github.com/whatwg/html/issues/8273 inspired me to make the generator be able to distinguish between iframes that have always existing vs iframes that are dynamically-created after step 0, for extra clarity.

Consider the following ([link](https://domenic.github.io/jake-diagram-generator/#IWN1cnJlbnQgPSAxCnRvcAogIDA6IC9wYWdlLTEgfCBkb2MxCiAgMTogL3BhZ2UtMSNhIHwgZG9jMQogIDI6IC9wYWdlLTEjYiB8IGRvYzEKICAzLTQ6IC9wYWdlLTEjYyB8IGRvYzEKaWZyYW1lOgogIDM6IC9pZnJhbWUtMQogIDQ6IC9pZnJhbWUtMg==)):

```
!current = 1
top
  0: /page-1 | doc1
  1: /page-1#a | doc1
  2: /page-1#b | doc1
  3-4: /page-1#c | doc1
iframe:
  3: /iframe-1
  4: /iframe-2
```

Here the user is trying to indicate that "iframe" didn't come into existence until step 3, yet today's generator creates the first iframe SHE at step 0, since the user didn't provide anything in between steps 0-3, which is a little awkward.

<img width="624" alt="Screen Shot 2022-09-10 at 1 35 40 AM" src="https://user-images.githubusercontent.com/9669289/189470707-dff57c6f-c2f6-4555-a10c-95e6f6bd752f.png">

To get around this, on the second-to-last line we could just course write `0-3: /iframe-1` but it then becomes impossible to distinguish between an iframe that has existed the entire time vs one that came into existence at step 3. Maybe that distinction is not important though! But if it is, this PR attempts to remedy this by creating a filler `<td>` starting at step 0 and spanning until the first user-supplied step in the navigable:

<img width="614" alt="Screen Shot 2022-09-10 at 1 29 47 AM" src="https://user-images.githubusercontent.com/9669289/189470759-ee2d3719-76a2-4d9d-b6cf-284d3540da74.png">

The filler `<td>` has the same doc color as the first real step, but has some styles indicating that it is just a filler. The only thing missing from this PR is correcting the ["current" class logic](https://github.com/domenic/jake-diagram-generator/blob/main/js/create-diagram.mjs#L79), so that if we're on step 2 in that diagram above, the "iframe" entry that is bolded is the doc in the earliest user-supplied entry (so `/iframe-1` in step 3 I guess?). I'll correct that logic if we think this PR in general is a worthwhile addition.